### PR TITLE
Use path.join instead of string concatenation to make usage of paths in env-variables more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,11 @@ https://api.playtak.com/api
 
 https://api.{env}.playtak.com
 
-/events
-
-/v1/games-history/
-/v1/games-history/{id}
-/v1/games-historoy/ptn/{id}
-/v1/hames-history/db
+- /events
+- /v1/games-history/
+- /v1/games-history/{id}
+- /v1/games-historoy/ptn/{id}
+- /v1/hames-history/db
 
 ## TODO
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,14 +5,16 @@ import { APP_GUARD } from '@nestjs/core';
 import { EventsModule } from './models/events/events.module';
 import { GamesModule } from './models/games-history/games.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import * as path from 'path';
+
 
 @Module({
 	imports: [
 		ConfigModule.forRoot(),
 		TypeOrmModule.forRoot({
 			type: 'sqlite',
-			database: process.env.DB_PATH + 'games.db',
-			entities: [__dirname + '/**/*.entity{.ts,.js}'],
+			database: path.join(process.env.DB_PATH, 'games.db'),
+			entities: [path.join(__dirname, '/**/*.entity{.ts,.js}')],
 			synchronize: false,
 		}),
 		EventsModule,

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,7 @@ async function bootstrap() {
 	if (process.env.DIST_PATH) {
 		dist = process.env.DIST_PATH;
 	}
-	const outputPath = path.resolve(process.cwd(), dist + 'swagger.json');
+	const outputPath = path.resolve(process.cwd(), path.join(dist, 'swagger.json'));
 	writeFileSync(outputPath, JSON.stringify(document), { encoding: 'utf8' });
 
 	app.enableCors({

--- a/src/models/events/events.service.ts
+++ b/src/models/events/events.service.ts
@@ -10,7 +10,7 @@ export class EventsService {
 	private SCOPES = ['https://www.googleapis.com/auth/spreadsheets'];
 	constructor() {
 		this.filePath = path.resolve(__dirname, '../../assets');
-		this.CREDENTIALS_PATH = this.filePath + '/client_secret.json';
+		this.CREDENTIALS_PATH = path.join(this.filePath, '/client_secret.json');
 	}
 
 	async getEvents(): Promise<EventList | NotFoundException | HttpException> {


### PR DESCRIPTION
- Use `path.join` instead of string concatenation to avoid misconfiguration
  - e.g. by forgetting the ending slash in `env:DB_PATH` 
- Make endpoints in README more readable (by adding linebreaks / using a list)