### PR TITLE
fix(ratings): adjust transaction commit order and update API endpoint

### DIFF
--- a/api/src/models/ratings/ratings.service.ts
+++ b/api/src/models/ratings/ratings.service.ts
@@ -307,6 +307,8 @@ export class RatingService {
 				}
 			}
 
+			await gameRunner.commitTransaction();
+			this.logger.debug('Finished updating games');
 			// update player query function
 			async function updatePlayer(rating: number, boost: number, ratedGames, maxRating, ratingAge, fatigueObject, id, participation_rating) {
 				const updatePlayerQuery = `UPDATE players SET
@@ -366,8 +368,8 @@ export class RatingService {
 					])
 				}
 			}
+
 			await playerRunner.commitTransaction();
-			await gameRunner.commitTransaction();
 		} catch (error) {
 			this.logger.error("Error processing player and game ratings, rolling back transaction. ", error);
 			playerRunner.rollbackTransaction();

--- a/api/test/bruno/playtak-api/test-suite/generate.bru
+++ b/api/test/bruno/playtak-api/test-suite/generate.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{url}}/rating/generate
+  url: {{url}}/v1/ratings/generate
   body: none
   auth: none
 }


### PR DESCRIPTION
- Move gameRunner.commitTransaction before player updates to ensure proper transaction order and ensures the less likelyhood of a DB lock
- Add debug logging after game updates completion
- Update API endpoint from /rating/generate to /v1/ratings/generate in test suite