### PR TITLE
Attempt to fix games not being spectate-able in beta

### DIFF
--- a/server/src/main/java/tak/Game.java
+++ b/server/src/main/java/tak/Game.java
@@ -408,7 +408,7 @@ public class Game implements Publisher<GameUpdate> {
 	void newSpectator(Player p) {
 		gameLock.lock();
 		try {
-			p.send("Observe " + stringForm(p.client.protocolVersion >= 4));
+			p.send("Observe " + stringForm(p.protocolVersion() >= 4));
 			sendMoveListTo(p);
 			spectators.add(p);
 			updateTime(p);
@@ -566,7 +566,7 @@ public class Game implements Publisher<GameUpdate> {
 
 	static void sendGameListTo(Player p) {
 		for (Integer no : Game.games.keySet()) {
-			p.sendWithoutLogging("GameList Add " + Game.games.get(no).stringForm(p.client.protocolVersion >= 4));
+			p.sendWithoutLogging("GameList Add " + Game.games.get(no).stringForm(p.protocolVersion() >= 4));
 		}
 	}
 
@@ -653,7 +653,7 @@ public class Game implements Publisher<GameUpdate> {
 		String withScale = "GameList " + action + " " + g.stringForm(true);
 		String withoutScale = "GameList " + action + " " + g.stringForm(false);
 		for (Player p : gameListeners) {
-			p.sendWithoutLogging(p.client.protocolVersion >= 4 ? withScale : withoutScale);
+			p.sendWithoutLogging(p.protocolVersion() >= 4 ? withScale : withoutScale);
 		}
 	}
 

--- a/server/src/main/java/tak/Player.java
+++ b/server/src/main/java/tak/Player.java
@@ -361,6 +361,15 @@ public class Player {
 		return client;
 	}
 
+	// Null-safe protocol version. `client` is set to null on logout/disconnect
+	// (see logout()/loggedOut()), yet a player may still linger in a broadcast
+	// set such as gameListeners or spectators. Callers iterating those sets must
+	// go through this instead of dereferencing `client` directly, or a single
+	// logged-out listener will NPE and abort the whole broadcast loop.
+	public int protocolVersion() {
+		return client != null ? client.protocolVersion : 0;
+	}
+
 	static SecureRandom random = new SecureRandom();
 
 	public static Player createPlayer(String name, String email) {


### PR DESCRIPTION
## Summary
Attempts to fix the bug where games in progress never appeared in the Watch Game list in beta. The root cause (according to Claude) seems to have been a server-side NullPointerException in the game-list broadcast.

## Root cause
The Protocol 4 game-list broadcast dereferences `p.client.protocolVersion` **directly** while iterating the `gameListeners` set:

```java
for (Player p : gameListeners) {
    p.sendWithoutLogging(p.client.protocolVersion >= 4 ? withScale : withoutScale);
}